### PR TITLE
python read_msgpack_file(), including pybitshuffle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ endif
 
 BINARIES := ch-frb-l1 ch-frb-simulate-l0 rpc-client test-l1-rpc
 
-all: $(BINARIES)
+all: $(BINARIES) bitshuffle.so
 .PHONY: all
 
 INCFILES := l1-rpc.hpp rpc.hpp
@@ -87,6 +87,11 @@ ch-frb-test-debug: ch-frb-test.cpp $(L1_OBJS) $(IO_OBJS)
 
 test-l1-rpc: test-l1-rpc.cpp $(L1_OBJS)
 	$(CPP) $(CPP_CFLAGS) $(CPP_LFLAGS) -o $@ $^ -lzmq -lhdf5 -llz4 -lch_frb_io
+
+# Python wrapper
+bitshuffle.so: pybitshuffle.c
+	gcc -c $^ $$(pkg-config --cflags python) -I$(INCDIR)
+	gcc -o $@ -shared pybitshuffle.o $$(pkg-config --libs python) -L$(LIBDIR) -lch_frb_io
 
 clean:
 	rm -f *.o *~ $(BINARIES)

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ endif
 
 BINARIES := ch-frb-l1 ch-frb-simulate-l0 rpc-client test-l1-rpc
 
-all: $(BINARIES) bitshuffle.so
+all: $(BINARIES) pybitshuffle.so
 .PHONY: all
 
 INCFILES := l1-rpc.hpp rpc.hpp
@@ -89,7 +89,7 @@ test-l1-rpc: test-l1-rpc.cpp $(L1_OBJS)
 	$(CPP) $(CPP_CFLAGS) $(CPP_LFLAGS) -o $@ $^ -lzmq -lhdf5 -llz4 -lch_frb_io
 
 # Python wrapper
-bitshuffle.so: pybitshuffle.c
+pybitshuffle.so: pybitshuffle.c
 	gcc -c $^ $$(pkg-config --cflags python) -I$(INCDIR)
 	gcc -o $@ -shared pybitshuffle.o $$(pkg-config --libs python) -L$(LIBDIR) -lch_frb_io
 

--- a/pybitshuffle.c
+++ b/pybitshuffle.c
@@ -1,0 +1,52 @@
+#define PY_SSIZE_T_CLEAN 1
+#include "Python.h"
+
+#include <stdio.h>
+#include <assert.h>
+
+//extern "C" {
+//  // UGH: c99
+//#define __STDC_VERSION__ 199901L
+#include <bitshuffle.h>
+//}
+
+static PyObject* bitshuffle_decompress(PyObject* self, PyObject* args) {
+    Py_ssize_t cbytes;
+    const char* cdata;
+    int ndecomp;
+    char* data;
+    
+    if (!PyArg_ParseTuple(args, "s#i", &cdata, &cbytes, &ndecomp))
+        return NULL;
+
+    printf("Got %i bytes to decompress into %i bytes\n", (int)cbytes, ndecomp);
+
+    data = malloc(ndecomp);
+    if (!data) {
+        PyErr_SetString(PyExc_MemoryError, "Failed to allocate space for bitshuffle-uncompressed data");
+        return NULL;
+    }
+    
+    int64_t n = bshuf_decompress_lz4(cdata, data, cbytes, 1, 0);
+    printf("Decompressed %i\n", (int)n);
+
+    if (n != ndecomp) {
+        PyErr_SetString(PyExc_ValueError, "Bitshuffle-decompressed data was not the size expected!");
+        free(data);
+        return NULL;
+    }
+    return PyByteArray_FromStringAndSize(data, ndecomp);
+}
+
+static PyMethodDef bitshuffleMethods[] = {
+    { "decompress", bitshuffle_decompress, METH_VARARGS,
+      "decompress bitshuffled data" },
+    {NULL, NULL, 0, NULL}
+};
+
+PyMODINIT_FUNC
+initbitshuffle(void) {
+    Py_InitModule("bitshuffle", bitshuffleMethods);
+    //import_array();
+}
+

--- a/pybitshuffle.c
+++ b/pybitshuffle.c
@@ -26,11 +26,22 @@ static PyObject* bitshuffle_decompress(PyObject* self, PyObject* args) {
         PyErr_SetString(PyExc_MemoryError, "Failed to allocate space for bitshuffle-uncompressed data");
         return NULL;
     }
-    
-    int64_t n = bshuf_decompress_lz4(cdata, data, cbytes, 1, 0);
-    printf("Decompressed %i\n", (int)n);
 
-    if (n != ndecomp) {
+    printf("Compressed data:\n");
+    int i,j,k=0;
+    const uint8_t* udata = cdata;
+    for (j=0; j<8; j++) {
+        for (i=0; i<8; i++) {
+            printf(" %3i", (int)udata[k]);
+            k++;
+        }
+        printf("\n");
+    }
+    
+    int64_t n = bshuf_decompress_lz4((const void*)cdata, (void*)data, (size_t)ndecomp, 1, 0);
+    printf("Decompressed: read %i\n", (int)n);
+
+    if (n != cbytes) {
         PyErr_SetString(PyExc_ValueError, "Bitshuffle-decompressed data was not the size expected!");
         free(data);
         return NULL;

--- a/pybitshuffle.c
+++ b/pybitshuffle.c
@@ -40,7 +40,7 @@ static PyMethodDef bitshuffleMethods[] = {
 };
 
 PyMODINIT_FUNC
-initbitshuffle(void) {
-    Py_InitModule("bitshuffle", bitshuffleMethods);
+initpybitshuffle(void) {
+    Py_InitModule("pybitshuffle", bitshuffleMethods);
 }
 

--- a/pybitshuffle.c
+++ b/pybitshuffle.c
@@ -3,43 +3,27 @@
 
 #include <stdio.h>
 #include <assert.h>
-
-//extern "C" {
-//  // UGH: c99
-//#define __STDC_VERSION__ 199901L
 #include <bitshuffle.h>
-//}
 
 static PyObject* bitshuffle_decompress(PyObject* self, PyObject* args) {
     Py_ssize_t cbytes;
     const char* cdata;
     int ndecomp;
     char* data;
-    
+
+    // Arguments: string of compressed data, int of decompressed size.
     if (!PyArg_ParseTuple(args, "s#i", &cdata, &cbytes, &ndecomp))
         return NULL;
 
-    printf("Got %i bytes to decompress into %i bytes\n", (int)cbytes, ndecomp);
-
+    //printf("Got %i bytes to decompress into %i bytes\n", (int)cbytes, ndecomp);
     data = malloc(ndecomp);
     if (!data) {
         PyErr_SetString(PyExc_MemoryError, "Failed to allocate space for bitshuffle-uncompressed data");
         return NULL;
     }
 
-    printf("Compressed data:\n");
-    int i,j,k=0;
-    const uint8_t* udata = cdata;
-    for (j=0; j<8; j++) {
-        for (i=0; i<8; i++) {
-            printf(" %3i", (int)udata[k]);
-            k++;
-        }
-        printf("\n");
-    }
-    
     int64_t n = bshuf_decompress_lz4((const void*)cdata, (void*)data, (size_t)ndecomp, 1, 0);
-    printf("Decompressed: read %i\n", (int)n);
+    //printf("Decompressed: read %i\n", (int)n);
 
     if (n != cbytes) {
         PyErr_SetString(PyExc_ValueError, "Bitshuffle-decompressed data was not the size expected!");
@@ -58,6 +42,5 @@ static PyMethodDef bitshuffleMethods[] = {
 PyMODINIT_FUNC
 initbitshuffle(void) {
     Py_InitModule("bitshuffle", bitshuffleMethods);
-    //import_array();
 }
 

--- a/rpc_client.py
+++ b/rpc_client.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 import zmq
 import msgpack
 import time
+import numpy as np
 
 '''
 Python client for the L1 RPC service.
@@ -46,13 +47,18 @@ class AssembledChunk(object):
              import bitshuffle
              print('compressed data:', len(data))
              print('Ndata:', self.ndata)
+
+             f = open('cdata.bin', 'wb')
+             f.write(data)
+             f.close()
+
              data = bitshuffle.decompress(data, self.ndata)
-             print('data:', data)
+             print('Decompressed data:', len(data))
 
           # Convert to numpy arrays
           self.scales = np.fromstring(scales, dtype='<f4')
           self.offsets = np.fromstring(offsets, dtype='<f4')
-          self.data = np.fromstring(data, dtype=np.uint8)
+          self.data = np.frombuffer(data, dtype=np.uint8)
           # could now reshape 'adata' into an nfreq_coarse x nupfreq x nt_per_assmbled_chunk array...
 
 def read_msgpack_file(fn):
@@ -60,9 +66,8 @@ def read_msgpack_file(fn):
     m = msgpack.unpackb(f.read())
     return AssembledChunk(m)
 
-c = read_msgpack_file('chunk-beam0077-chunk00000094+01.msgpack')
-print('Got', c)
-sys.exit(0)
+# c = read_msgpack_file('chunk-beam0077-chunk00000094+01.msgpack')
+# print('Got', c)
 
 
 class WriteChunkReply(object):

--- a/rpc_client.py
+++ b/rpc_client.py
@@ -14,6 +14,57 @@ results.
 This client can talk to multiple RPC servers at once.
 '''
 
+class AssembledChunk(object):
+      def __init__(self, msgpacked_chunk):
+          c = msgpacked_chunk
+          print('header', c[0])
+          version = c[1]
+          assert(version == 1)
+          print('version', version)
+          compressed = c[2]
+          print('compressed?', compressed)
+          compressed_size = c[3]
+          print('compressed size', compressed_size)
+          self.beam = c[4]
+          self.nupfreq = c[5]
+          self.nt_per_packet = c[6]
+          self.fpga_counts_per_sample = c[7]
+          self.nt_coarse = c[8]
+          self.nscales = c[9]
+          self.ndata   = c[10]
+          self.fpga0   = c[11]
+          self.fpgaN   = c[12]
+          self.binning = c[13]
+
+          scales  = c[14]
+          offsets = c[15]
+          data    = c[16]
+
+          #
+          #assert(not compressed)
+          if compressed:
+             import bitshuffle
+             print('compressed data:', len(data))
+             print('Ndata:', self.ndata)
+             data = bitshuffle.decompress(data, self.ndata)
+             print('data:', data)
+
+          # Convert to numpy arrays
+          self.scales = np.fromstring(scales, dtype='<f4')
+          self.offsets = np.fromstring(offsets, dtype='<f4')
+          self.data = np.fromstring(data, dtype=np.uint8)
+          # could now reshape 'adata' into an nfreq_coarse x nupfreq x nt_per_assmbled_chunk array...
+
+def read_msgpack_file(fn):
+    f = open(fn, 'rb')
+    m = msgpack.unpackb(f.read())
+    return AssembledChunk(m)
+
+c = read_msgpack_file('chunk-beam0077-chunk00000094+01.msgpack')
+print('Got', c)
+sys.exit(0)
+
+
 class WriteChunkReply(object):
     '''
     Python version of rpc.hpp : WriteChunks_Reply: the RPC server's

--- a/rpc_client.py
+++ b/rpc_client.py
@@ -41,22 +41,12 @@ class AssembledChunk(object):
           offsets = c[15]
           data    = c[16]
 
-          #
-          #assert(not compressed)
           if compressed:
-             import bitshuffle
-             print('compressed data:', len(data))
-             print('Ndata:', self.ndata)
-
-             f = open('cdata.bin', 'wb')
-             f.write(data)
-             f.close()
-
-             data = bitshuffle.decompress(data, self.ndata)
-             print('Decompressed data:', len(data))
+             import pybitshuffle
+             data = pybitshuffle.decompress(data, self.ndata)
 
           # Convert to numpy arrays
-          self.scales = np.fromstring(scales, dtype='<f4')
+          self.scales  = np.fromstring(scales , dtype='<f4')
           self.offsets = np.fromstring(offsets, dtype='<f4')
           self.data = np.frombuffer(data, dtype=np.uint8)
           # could now reshape 'adata' into an nfreq_coarse x nupfreq x nt_per_assmbled_chunk array...


### PR DESCRIPTION
I don't know if this should go in ch_frb_io or ch_frb_l1.

This adds python code to read an assembled_chunk object from a msgpack file, in python: function "read_msgpack_file()".  Since these files are bitshuffle compressed, I added a little python wrapper, pybitshuffle.c.

