### PR TITLE
decrease the number of threads started by the civetweb server

### DIFF
--- a/l1-prometheus.cpp
+++ b/l1-prometheus.cpp
@@ -253,6 +253,9 @@ shared_ptr<L1PrometheusServer> start_prometheus_server(string ipaddr_port,
     // listening_ports = [ipaddr:]port
     options.push_back("listening_ports");
     options.push_back(ipaddr_port);
+    // default is 50, but we're only serving the prometheus poller
+    options.push_back("num_threads");
+    options.push_back(std::to_string(8));
     shared_ptr<L1PrometheusServer> server;
     try {
         server = make_shared<L1PrometheusServer>(options);


### PR DESCRIPTION
(civetweb is the embedded web server for answering prometheus requests)

Did this because we were getting Too Many Open Files errors on cf0g0..3.  Default ulimit was 1024, and civet was using 2 web servers x 50 threads x 4 file handles each (from the OS)

