### PR TITLE
Allow recording the number of data samples masked by the RFI chain and exposing through prometheus and RPC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ all: $(INSTALLED_BINARIES) $(NON_INSTALLED_BINARIES)
 
 INCFILES := ch_frb_l1.hpp l0-sim.hpp l1-rpc.hpp rpc.hpp
 
-L1_OBJS := l1-rpc.o
+L1_OBJS := l1-rpc.o mask_stats.o
 
 # Append compile flags
 CPP_CFLAGS ?=

--- a/ch-frb-l1.cpp
+++ b/ch-frb-l1.cpp
@@ -815,9 +815,9 @@ void dedispersion_thread_context::_thread_main() const
         vector<shared_ptr<rf_pipelines::pipeline_object> > stages;
         pipeline_get_all(rfi_chain, stages);
         for (auto &it : stages) {
-            cout << "pipeline stage: class " << it->class_name << endl;
+            //cout << "pipeline stage: class " << it->class_name << endl;
             if (it->class_name == "mask_counter") {
-                cout << "  casting to mask_counter_transform and registering callback!" << endl;
+                cout << "Found mask_counter_transform -- registering callback.  name: " << it->name << endl;
                 shared_ptr<rf_pipelines::mask_counter_transform> counter = dynamic_pointer_cast<rf_pipelines::mask_counter_transform>(it);
                 counter->add_callback(ms);
             }

--- a/ch-frb-l1.cpp
+++ b/ch-frb-l1.cpp
@@ -1288,7 +1288,7 @@ void l1_server::make_rpc_servers()
     this->rpc_threads.resize(config.nstreams);
     
     for (int istream = 0; istream < config.nstreams; istream++) {
-	rpc_servers[istream] = make_shared<L1RpcServer> (input_streams[istream], config.rpc_address[istream], command_line);
+	rpc_servers[istream] = make_shared<L1RpcServer> (input_streams[istream], mask_stats_objects[istream], config.rpc_address[istream], command_line);
 	rpc_threads[istream] = rpc_servers[istream]->start();
     }
 }

--- a/ch-frb-l1.cpp
+++ b/ch-frb-l1.cpp
@@ -724,7 +724,7 @@ struct dedispersion_thread_context {
 };
 
 static void pipeline_get_all(shared_ptr<rf_pipelines::pipeline_object> pipe,
-                             vector<shared_ptr<rf_pipelines::pipeline_object> > stages) {
+                             vector<shared_ptr<rf_pipelines::pipeline_object> > &stages) {
     stages.push_back(pipe);
     if (pipe->class_name == "pipeline") {
         shared_ptr<rf_pipelines::pipeline> pipeline = dynamic_pointer_cast<rf_pipelines::pipeline>(pipe);
@@ -810,11 +810,14 @@ void dedispersion_thread_context::_thread_main() const
     print_pipeline(rfi_chain, "");
 
     if (ms) {
+        cout << "mask_stats object specified.  Finding mask_counter stage..." << endl;
         // Find mask_counter stage(s).
         vector<shared_ptr<rf_pipelines::pipeline_object> > stages;
         pipeline_get_all(rfi_chain, stages);
         for (auto &it : stages) {
+            cout << "pipeline stage: class " << it->class_name << endl;
             if (it->class_name == "mask_counter") {
+                cout << "  casting to mask_counter_transform and registering callback!" << endl;
                 shared_ptr<rf_pipelines::mask_counter_transform> counter = dynamic_pointer_cast<rf_pipelines::mask_counter_transform>(it);
                 counter->add_callback(ms);
             }
@@ -1316,6 +1319,7 @@ void l1_server::spawn_dedispersion_threads()
 	dedispersion_thread_context context;
 	context.config = this->config;
 	context.sp = this->input_streams[istream];
+        context.ms = this->mask_stats_objects[istream];
 	context.l1b_subprocess = this->l1b_subprocesses[ibeam];
 	context.allowed_cores = this->dedispersion_cores[ibeam];
 	context.asynchronous_dedispersion = this->asynchronous_dedispersion;

--- a/ch-frb-l1.cpp
+++ b/ch-frb-l1.cpp
@@ -819,6 +819,7 @@ void dedispersion_thread_context::_thread_main() const
             if (it->class_name == "mask_counter") {
                 cout << "Found mask_counter_transform -- registering callback.  name: " << it->name << endl;
                 shared_ptr<rf_pipelines::mask_counter_transform> counter = dynamic_pointer_cast<rf_pipelines::mask_counter_transform>(it);
+                ms->_where = counter->where;
                 counter->add_callback(ms);
             }
         }

--- a/ch-frb-simulate-l0.cpp
+++ b/ch-frb-simulate-l0.cpp
@@ -264,7 +264,6 @@ void data_thread_main(const shared_ptr<ch_frb_io::intensity_network_ostream> &os
                       const vector<string> &filenames)
 {
     assert(ostream->target_gbps > 0.0);
-    int nchunks = filenames.size();
 
     vector<pair<vector<float>,vector<float> > > data;
 
@@ -276,7 +275,8 @@ void data_thread_main(const shared_ptr<ch_frb_io::intensity_network_ostream> &os
             return;
         }
 
-        cout << "chunk: nupfreq " << chunk->nupfreq  << ", nt_per_packet " << chunk->nt_per_packet << ", fgpa_counts_per_sample " << chunk->fpga_counts_per_sample << ", nt_coarse " << chunk->nt_coarse << ", nscales " << chunk->nscales << ", ndata " << chunk->ndata << endl;
+        cout << "chunk: nupfreq " << chunk->nupfreq  << ", nt_per_packet " << chunk->nt_per_packet << ", fgpa_counts_per_sample " << chunk->fpga_counts_per_sample << ", nt_coarse " << chunk->nt_coarse << ", nscales " << chunk->nscales << ", ndata " << chunk->ndata << ", beam " << chunk->beam_id << ", fpga_begin " << chunk->fpga_begin <<endl;
+
         //cout << "elts per chunk " << ostream->elts_per_chunk << ", nt per chunk " << ostream->nt_per_chunk << endl;
         int nsub = chunk->nt_coarse * chunk->nt_per_packet / ostream->nt_per_chunk;
         cout << "splitting assembled chunk into " << nsub << " pieces" << endl;
@@ -309,7 +309,7 @@ void data_thread_main(const shared_ptr<ch_frb_io::intensity_network_ostream> &os
     }
 
 
-    for (int ichunk = 0; ichunk < nchunks; ichunk++) {
+    for (int ichunk = 0; ichunk < data.size(); ichunk++) {
 	int64_t fpga_count = int64_t(ichunk) * int64_t(ostream->fpga_counts_per_chunk);
         int stride = ostream->nt_per_chunk;
         pair<vector<float>,vector<float> > iw = data[ichunk];

--- a/l0_configs/l0_data.yml
+++ b/l0_configs/l0_data.yml
@@ -1,0 +1,13 @@
+nbeams: 1
+nfreq: 16384
+nt_per_packet: 16
+
+ipaddr: "127.0.0.1"
+port: [6677]
+
+# Total number of threads used by the L0 simulator.
+# Note: nthreads must be a multiple of the number of "streams", which
+# is the number of distinct (ipaddr,port) pairs (in this case nsteams=2).
+
+nthreads: 1
+

--- a/l0_configs/l0_dstn.yml
+++ b/l0_configs/l0_dstn.yml
@@ -1,0 +1,21 @@
+
+# nt_per_packet=16 is important here, since the 'fast' kernels are hardcoded to
+# use nt_per_packet=16.  See MANUAL.md for more dicussion!
+
+nbeams: 64
+nfreq: 1024
+nt_per_packet: 16
+
+# This example assumes the nodes are in a non-link-bonded configuration, where
+# each of the four 1 Gbps NIC's is on an independent /24 network.  We use UDP
+# port 6677 on all four NIC's.  Traffic is divided between NIC's "per beam", 
+# i.e. four beams will be sent to each NIC.
+
+ipaddr: "127.0.0.1"
+port: [7000, 7001, 7002, 7003, 7004, 7005, 7006, 7007 ]
+
+# Total number of threads used by the L0 simulator.
+# Note: nthreads must be a multiple of the number of "streams", which
+# is the number of distinct (ipaddr,port) pairs (in this case nsteams=2).
+
+nthreads: 8

--- a/l1-prometheus.cpp
+++ b/l1-prometheus.cpp
@@ -14,7 +14,7 @@ using namespace ch_frb_io;
 class L1PrometheusHandler : public CivetHandler {
 public:
     L1PrometheusHandler(shared_ptr<intensity_network_stream> stream,
-                        shared_ptr<ch_frb_l1::mask_stats> ms) :
+                        vector<shared_ptr<ch_frb_l1::mask_stats> > ms) :
         CivetHandler(),
         _stream(stream),
         _mask_stats(ms) {}
@@ -230,7 +230,7 @@ public:
 
 protected:
     shared_ptr<intensity_network_stream> _stream;
-    shared_ptr<ch_frb_l1::mask_stats> _mask_stats;
+    vector<shared_ptr<ch_frb_l1::mask_stats> > _mask_stats;
 };
 
 /*
@@ -252,7 +252,7 @@ public:
 
 shared_ptr<L1PrometheusServer> start_prometheus_server(string ipaddr_port,
                                                        shared_ptr<intensity_network_stream> stream,
-                                                       shared_ptr<ch_frb_l1::mask_stats> ms) {
+                                                       vector<shared_ptr<ch_frb_l1::mask_stats> > ms) {
     //"document_root", DOCUMENT_ROOT, "listening_ports", PORT, 0};
     std::vector<std::string> options;
     // listening_ports = [ipaddr:]port

--- a/l1-prometheus.cpp
+++ b/l1-prometheus.cpp
@@ -237,6 +237,7 @@ public:
                  "Total fraction of frequency channels that are fully masked"},
             };
             vector<tuple<int, string, unordered_map<string, float> > > maskstats;
+            float period = 15.;
             for (auto &it : _mask_stats) {
                 maskstats.push_back(make_tuple(it.first.first, it.first.second, it.second->get_stats(period)));
             }

--- a/l1-prometheus.cpp
+++ b/l1-prometheus.cpp
@@ -229,11 +229,11 @@ public:
         // RFI masking stats per-beam.
         if (_mask_stats.size()) {
             struct metric_stat ms5[] = {
-                {"rfi_mask_pct_masked", "",
+                {"rfi_mask_pct_masked", "rfi_mask_pct_masked",
                  "Total fraction of samples masked"},
-                {"rfi_mask_pct_t_masked", "",
+                {"rfi_mask_pct_t_masked", "rfi_mask_pct_times_masked",
                  "Total fraction of times samples that are fully masked"},
-                {"rfi_mask_pct_f_masked", "",
+                {"rfi_mask_pct_f_masked", "rfi_mask_pct_frequencies_masked",
                  "Total fraction of frequency channels that are fully masked"},
             };
             vector<tuple<int, string, unordered_map<string, float> > > maskstats;
@@ -251,7 +251,7 @@ public:
                     unordered_map<string, float> mstats;
                     std::tie(beam_id, where, mstats) = maskstats[ib];
                     const char* key = ms5[i].key;
-                    mg_printf(conn, "%s{beam=\"%i\",where=\"%s\"} %f\n", name,
+                    mg_printf(conn, "%s{beam=\"%i\",where=\"%s\"} %.2f\n", name,
                               beam_id, where.c_str(), mstats[key]);
                 }
             }

--- a/l1-prometheus.cpp
+++ b/l1-prometheus.cpp
@@ -267,14 +267,6 @@ protected:
     ch_frb_l1::mask_stats_map _mask_stats;
 };
 
-/*
-class PrometheusServer {
-public:
-    PrometheusServer(shared_ptr<CivetServer> cs) :
-        _civet(cs) {}
-protected:
-};
- */
 class L1PrometheusServer : public CivetServer {
 public:
     L1PrometheusServer(std::vector<std::string> options,

--- a/l1-prometheus.cpp
+++ b/l1-prometheus.cpp
@@ -4,6 +4,7 @@
 #include <ch_frb_io.hpp>
 #include <l1-rpc.hpp>
 #include <chlog.hpp>
+#include <mask_stats.hpp>
 
 using namespace std;
 using namespace ch_frb_io;
@@ -12,9 +13,11 @@ using namespace ch_frb_io;
 
 class L1PrometheusHandler : public CivetHandler {
 public:
-    L1PrometheusHandler(shared_ptr<intensity_network_stream> stream) :
+    L1PrometheusHandler(shared_ptr<intensity_network_stream> stream,
+                        shared_ptr<ch_frb_l1::mask_stats> ms) :
         CivetHandler(),
-        _stream(stream) {}
+        _stream(stream),
+        _mask_stats(ms) {}
 
     bool handleGet(CivetServer *server, struct mg_connection *conn) {
         mg_printf(conn,
@@ -227,6 +230,7 @@ public:
 
 protected:
     shared_ptr<intensity_network_stream> _stream;
+    shared_ptr<ch_frb_l1::mask_stats> _mask_stats;
 };
 
 /*
@@ -247,7 +251,8 @@ public:
 };
 
 shared_ptr<L1PrometheusServer> start_prometheus_server(string ipaddr_port,
-                                                       shared_ptr<intensity_network_stream> stream) {
+                                                       shared_ptr<intensity_network_stream> stream,
+                                                       shared_ptr<ch_frb_l1::mask_stats> ms) {
     //"document_root", DOCUMENT_ROOT, "listening_ports", PORT, 0};
     std::vector<std::string> options;
     // listening_ports = [ipaddr:]port
@@ -265,7 +270,7 @@ shared_ptr<L1PrometheusServer> start_prometheus_server(string ipaddr_port,
         return server;
     }
     // we're going to memory-leak this handler object
-    L1PrometheusHandler* h = new L1PrometheusHandler(stream);
+    L1PrometheusHandler* h = new L1PrometheusHandler(stream, ms);
     server->addHandler("/metrics", h);
     return server;
 }

--- a/l1-prometheus.hpp
+++ b/l1-prometheus.hpp
@@ -5,11 +5,13 @@
 
 #include <ch_frb_io.hpp>
 
+#include <mask_stats.hpp>
+
 class L1PrometheusServer;
 
 // *ipaddr_port*: [ipaddr:]port
 std::shared_ptr<L1PrometheusServer> start_prometheus_server(std::string ipaddr_port,
-                                                          std::shared_ptr<ch_frb_io::intensity_network_stream> st);
-
+                                                            std::shared_ptr<ch_frb_io::intensity_network_stream> st,
+                                                            std::shared_ptr<ch_frb_l1::mask_stats> ms);
 
 #endif

--- a/l1-prometheus.hpp
+++ b/l1-prometheus.hpp
@@ -12,6 +12,6 @@ class L1PrometheusServer;
 // *ipaddr_port*: [ipaddr:]port
 std::shared_ptr<L1PrometheusServer> start_prometheus_server(std::string ipaddr_port,
                                                             std::shared_ptr<ch_frb_io::intensity_network_stream> st,
-                                                            std::shared_ptr<ch_frb_l1::mask_stats> ms);
+                                                            std::vector<std::shared_ptr<ch_frb_l1::mask_stats> > ms);
 
 #endif

--- a/l1-prometheus.hpp
+++ b/l1-prometheus.hpp
@@ -12,6 +12,6 @@ class L1PrometheusServer;
 // *ipaddr_port*: [ipaddr:]port
 std::shared_ptr<L1PrometheusServer> start_prometheus_server(std::string ipaddr_port,
                                                             std::shared_ptr<ch_frb_io::intensity_network_stream> st,
-                                                            std::vector<std::shared_ptr<ch_frb_l1::mask_stats> > ms);
+                                                            ch_frb_l1::mask_stats_map ms);
 
 #endif

--- a/l1-rpc.cpp
+++ b/l1-rpc.cpp
@@ -905,13 +905,17 @@ int L1RpcServer::_handle_request(zmq::message_t* client, zmq::message_t* request
             shared_ptr<ch_frb_l1::mask_stats> ms = it.second;
             vector<rf_pipelines::mask_counter_measurements> meas = ms->get_all_measurements();
             cout << "Got " << meas.size() << " measurements from beam " << beam_id << " where " << where << endl;
-            pk.pack_array(3);
+            pk.pack_array(4);
             pk.pack(beam_id);
             pk.pack(where);
+            int nt = 0;
+            if (meas.size())
+                nt = meas[0].nt;
+            pk.pack(nt);
             pk.pack_array(meas.size());
             for (const auto &m : meas) {
                 pk.pack_array(m.nf);
-                bool* fm = m.freqs_masked.get();
+                uint16_t* fm = m.freqs_masked.get();
                 for (int k=0; k<m.nf; k++)
                     pk.pack(fm[k]);
             }

--- a/l1-rpc.cpp
+++ b/l1-rpc.cpp
@@ -222,6 +222,7 @@ void l1_write_request::write_callback(const string &error_message)
 
 
 L1RpcServer::L1RpcServer(shared_ptr<ch_frb_io::intensity_network_stream> stream,
+                         ch_frb_l1::mask_stats_map ms,
                          const string &port,
                          const string &cmdline,
                          zmq::context_t *ctx) :
@@ -232,7 +233,8 @@ L1RpcServer::L1RpcServer(shared_ptr<ch_frb_io::intensity_network_stream> stream,
     _backend_queue(make_shared<l1_backend_queue>()),
     _output_devices(stream->ini_params.output_devices),
     _shutdown(false),
-    _stream(stream)
+    _stream(stream),
+    _mask_stats(ms)
 {
     if (port.length())
         _port = port;

--- a/l1-rpc.cpp
+++ b/l1-rpc.cpp
@@ -893,8 +893,8 @@ int L1RpcServer::_handle_request(zmq::message_t* client, zmq::message_t* request
         // no arguments?
 
         // Returns:
-        // list of [beam_id, where, [ measurements ] ]
-        // where measurements is a list of booleans, one per freq bin
+        // list of [beam_id, where, nt, [ measurements ] ]
+        // where measurements is a list of uint16_ts, one per freq bin
 
         msgpack::sbuffer buffer;
         msgpack::packer<msgpack::sbuffer> pk(&buffer);
@@ -926,6 +926,44 @@ int L1RpcServer::_handle_request(zmq::message_t* client, zmq::message_t* request
         return _send_frontend_message(*client, *token_to_message(token),
                                       *reply);
 
+    } else if (funcname == "get_masked_times") {
+
+        // no arguments?
+
+        // Returns:
+        // list of [beam_id, where, nf, [ measurements ] ]
+        // where measurements is a list of uint16_t values, one per time bin
+
+        msgpack::sbuffer buffer;
+        msgpack::packer<msgpack::sbuffer> pk(&buffer);
+        pk.pack_array(_mask_stats.size());
+        for (auto &it : _mask_stats) {
+            int beam_id = it.first.first;
+            string where = it.first.second;
+            shared_ptr<ch_frb_l1::mask_stats> ms = it.second;
+            vector<rf_pipelines::mask_counter_measurements> meas = ms->get_all_measurements();
+            cout << "Got " << meas.size() << " measurements from beam " << beam_id << " where " << where << endl;
+            pk.pack_array(4);
+            pk.pack(beam_id);
+            pk.pack(where);
+            int nf = 0;
+            if (meas.size())
+                nf = meas[0].nf;
+            pk.pack(nf);
+            pk.pack_array(meas.size());
+            for (const auto &m : meas) {
+                pk.pack_array(m.nf);
+                uint16_t* tm = m.times_masked.get();
+                for (int k=0; k<m.nt; k++)
+                    pk.pack(tm[k]);
+            }
+        }
+
+        //  Send reply back to client.
+        zmq::message_t* reply = sbuffer_to_message(buffer);
+        return _send_frontend_message(*client, *token_to_message(token),
+                                      *reply);
+        
     } else {
         // Silent failure?
         chlog("Error: unknown RPC function name: " << funcname);

--- a/l1-rpc.hpp
+++ b/l1-rpc.hpp
@@ -9,6 +9,7 @@
 #include <condition_variable>
 #include <zmq.hpp>
 #include <ch_frb_io.hpp>
+#include <mask_stats.hpp>
 
 const int default_port_l1_rpc = 5555;
 
@@ -21,6 +22,7 @@ public:
     // Creates a new RPC server listening on the given port, and reading
     // from the ring buffers of the given stream.
     L1RpcServer(std::shared_ptr<ch_frb_io::intensity_network_stream> stream,
+                ch_frb_l1::mask_stats_map maskstats,
                 const std::string &port = "",
                 const std::string &cmdline = "",
                 zmq::context_t* ctx = NULL);
@@ -103,6 +105,9 @@ private:
 
     // the stream we are serving RPC requests for.
     std::shared_ptr<ch_frb_io::intensity_network_stream> _stream;
+
+    // objects holding RFI mask statistics
+    ch_frb_l1::mask_stats_map _mask_stats;
 
     // server start time
     struct timeval _time0;

--- a/l1_configs/l1_dstn.yaml
+++ b/l1_configs/l1_dstn.yaml
@@ -1,0 +1,52 @@
+# This is "example 1", in the section "Quick-start examples
+# which can be run on a laptop" in MANUAL.md.
+
+
+# This toy L1 server instance expects 1 beam, with 1024 frequencies.
+#
+# In subscale test programs, the value of 'nt_per_packet' isn't very important, but
+# should be the same on the L0 simulator and the L1 server.  (For discussion, see
+# "Config file reference: L1 server" in MANUAL.md.)
+
+nbeams: 1
+nfreq: 16384
+nt_per_packet: 16
+
+
+# Configure the L1 server to use the loopback interface 127.0.0.1 and UDP port 6677.
+# The RPC server will run on TCP port 5555.
+
+ipaddr: "127.0.0.1"
+port: 6677
+rpc_address: "tcp://127.0.0.1:5555"
+prometheus_address: "127.0.0.1:8888"
+
+# This configures the L1 server to use a single I/O thread for all writes.
+# See 'output_devices' in MANUAL.md for discussion!
+output_devices: ""
+
+
+slow_kernels: False
+
+
+# Buffer configuration.  For documentation on these parameters, see 
+# "Config file reference: L1 server" in MANUAL.md.
+
+assembled_ringbuf_nsamples: 4096
+telescoping_ringbuf_nsamples: [ 4096, 4096, 4096 ]
+write_staging_area_gb: 0.1
+
+
+# L1b configuration.
+#
+# Postprocess triggers using 'toy-l1b.py', a placeholder version
+# of the L1b code which "processes" coarse-grained triggers by
+# making a big waterfall plot (toy_l1b_beam0.png).
+#
+# The parameter combination (l1b_buffer_nsamples, l1b_pipe_timeout) = (0, 5.0)
+# makes sense for subscale test instances, but not in the production real-time
+# search.  See MANUAL.md for discussion!
+
+l1b_executable_filename: "./toy-l1b.py"
+l1b_buffer_nsamples: 0
+l1b_pipe_timeout: 5.0

--- a/l1_configs/l1_dstn.yaml
+++ b/l1_configs/l1_dstn.yaml
@@ -21,6 +21,8 @@ port: 6677
 rpc_address: "tcp://127.0.0.1:5555"
 prometheus_address: "127.0.0.1:8888"
 
+# beam_ids: [ 139 ]
+
 # This configures the L1 server to use a single I/O thread for all writes.
 # See 'output_devices' in MANUAL.md for discussion!
 output_devices: ""
@@ -50,3 +52,5 @@ write_staging_area_gb: 0.1
 l1b_executable_filename: "./toy-l1b.py"
 l1b_buffer_nsamples: 0
 l1b_pipe_timeout: 5.0
+
+#stream_acqname: "test_acq"

--- a/l1_configs/l1_example1.yaml
+++ b/l1_configs/l1_example1.yaml
@@ -19,6 +19,7 @@ nt_per_packet: 64
 ipaddr: "127.0.0.1"
 port: 6677
 rpc_address: "tcp://127.0.0.1:5555"
+prometheus_address: "127.0.0.1:8888"
 
 # This configures the L1 server to use a single I/O thread for all writes.
 # See 'output_devices' in MANUAL.md for discussion!

--- a/mask_stats.cpp
+++ b/mask_stats.cpp
@@ -68,18 +68,24 @@ unordered_map<string, float> mask_stats::get_stats(float history) {
         if (nsteps > _meas.size())
             nsteps = _meas.size();
         int istart = (_imeas - nsteps + _maxmeas) % _maxmeas;
-        int iend = (istart + nsteps) % _maxmeas;
-        cout << "History: " << history << " imeas=" << _imeas << ", max="
-             << _maxmeas << " -> istart " << istart << ", iend " << iend << endl;
-        for (int i=istart; i<(istart + nsteps); i=(i + 1) % _maxmeas) {
+        //cout << "History: " << history << " imeas=" << _imeas << ", max="
+        //<< _maxmeas << " -> istart " << istart << endl;
+        //cout << "Gathering stats" << endl;
+        for (int offset=0; offset<nsteps; offset++) {
+            int i = (istart + offset) % _maxmeas;
             totsamp += _meas[i].nsamples;
             totmasked += _meas[i].nsamples_masked;
             tot_t += _meas[i].nt;
             tot_tmasked += _meas[i].nt_masked;
-            tot_fmasked += _meas[i].nf_masked;
             tot_f += _meas[i].nf;
+            tot_fmasked += _meas[i].nf_masked;
+            //cout << "  pos " << _meas[i].pos << " ns " << _meas[i].nsamples_masked << "/" <<_meas[i].nsamples << ", nt " << _meas[i].nt_masked << "/" << _meas[i].nt << ", nf " << _meas[i].nf_masked << "/" << _meas[i].nf << endl;
         }
     }
+    //cout << "Percentages: " << (100. * totmasked / max(totsamp, 1.f))
+    //<< ", " << (100. * tot_tmasked / max(tot_t, 1.f))
+    //<< ", " << (100. * tot_fmasked / max(tot_f, 1.f)) << endl;
+
     stats["rfi_mask_pct_masked"]   = 100. * totmasked / max(totsamp, 1.f);
     stats["rfi_mask_pct_t_masked"] = 100. * tot_tmasked / max(tot_t, 1.f);
     stats["rfi_mask_pct_f_masked"] = 100. * tot_fmasked / max(tot_f, 1.f);

--- a/mask_stats.cpp
+++ b/mask_stats.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <iostream>
 #include <mask_stats.hpp>
 
@@ -66,9 +67,9 @@ unordered_map<string, float> mask_stats::get_stats(float history) {
             tot_f += _meas[i].nf;
         }
     }
-    stats["rfi_mask_pct_masked"]   = 100. * totmasked / totsamp;
-    stats["rfi_mask_pct_t_masked"] = 100. * tot_tmasked / tot_t;
-    stats["rfi_mask_pct_f_masked"] = 100. * tot_fmasked / tot_f;
+    stats["rfi_mask_pct_masked"]   = 100. * totmasked / max(totsamp, 1.f);
+    stats["rfi_mask_pct_t_masked"] = 100. * tot_tmasked / max(tot_t, 1.f);
+    stats["rfi_mask_pct_f_masked"] = 100. * tot_fmasked / max(tot_f, 1.f);
     return stats;
 }
     

--- a/mask_stats.cpp
+++ b/mask_stats.cpp
@@ -6,13 +6,23 @@ using namespace rf_pipelines;
 using namespace ch_frb_io;
 using namespace ch_frb_l1;
 
-mask_stats::mask_stats() {
-}
+mask_stats::mask_stats(int beam_id, int nhistory) :
+    _beam_id(beam_id),
+    _imeas(0),
+    _maxmeas(nhistory)
+{}
 
 mask_stats::~mask_stats() {
 }
 
 void mask_stats::mask_count(const struct rf_pipelines::mask_counter_measurements& meas) {
-    cout << "mask_stats: got pos " << meas.pos << ": N samples masked: " << meas.nsamples_masked << "/" << meas.nsamples << "; n times " << meas.nt_masked << "/" << meas.nt << "; n freqs " << meas.nf_masked << "/" << meas.nf << endl;
+    cout << "mask_stats: beam " << _beam_id << " got pos " << meas.pos << ": N samples masked: " << meas.nsamples_masked << "/" << meas.nsamples << "; n times " << meas.nt_masked << "/" << meas.nt << "; n freqs " << meas.nf_masked << "/" << meas.nf << endl;
+
+    if (_imeas < _maxmeas)
+        _meas.push_back(meas);
+    else
+        // ring buffer
+        _meas[_imeas] = meas;
+    _imeas++;
 }
 

--- a/mask_stats.cpp
+++ b/mask_stats.cpp
@@ -38,6 +38,19 @@ void mask_stats::mask_count(const struct rf_pipelines::mask_counter_measurements
     }
 }
 
+vector<rf_pipelines::mask_counter_measurements>
+mask_stats::get_all_measurements() {
+    vector<rf_pipelines::mask_counter_measurements> copy;
+    {
+        ulock l(_meas_mutex);
+        // Reorder the ring buffer.
+        int n = _meas.size();
+        for (int off=0; off<n; off++)
+            copy.push_back(_meas[(_imeas + 1 + off) % n]);
+    }
+    return copy;
+}
+
 unordered_map<string, float> mask_stats::get_stats(float history) {
     unordered_map<string, float> stats;
 

--- a/mask_stats.cpp
+++ b/mask_stats.cpp
@@ -30,6 +30,11 @@ void mask_stats::mask_count(const struct rf_pipelines::mask_counter_measurements
             _meas[_imeas] = meas;
         _imeas = (_imeas + 1) % _maxmeas;
     }
+
+    unordered_map<string, float> stats = get_stats(5.);
+    for (const auto &it : stats) {
+        cout << "  " << it.first << " = " << it.second << endl;
+    }
 }
 
 unordered_map<string, float> mask_stats::get_stats(float history) {
@@ -43,6 +48,7 @@ unordered_map<string, float> mask_stats::get_stats(float history) {
     float tot_t = 0;
     float tot_tmasked = 0;
     float tot_fmasked = 0;
+    float tot_f = 0;
     {
         ulock l(_meas_mutex);
         if (nsteps > _meas.size())
@@ -57,11 +63,12 @@ unordered_map<string, float> mask_stats::get_stats(float history) {
             tot_t += _meas[i].nt;
             tot_tmasked += _meas[i].nt_masked;
             tot_fmasked += _meas[i].nf_masked;
+            tot_f += _meas[i].nf;
         }
     }
-    stats["rfi_mask_pct_masked"] = 100. * totmasked / totsamp;
+    stats["rfi_mask_pct_masked"]   = 100. * totmasked / totsamp;
     stats["rfi_mask_pct_t_masked"] = 100. * tot_tmasked / tot_t;
-    stats["rfi_mask_pct_f_masked"] = 100. * tot_fmasked / (float)nsteps;
+    stats["rfi_mask_pct_f_masked"] = 100. * tot_fmasked / tot_f;
     return stats;
 }
     

--- a/mask_stats.cpp
+++ b/mask_stats.cpp
@@ -6,8 +6,11 @@ using namespace rf_pipelines;
 using namespace ch_frb_io;
 using namespace ch_frb_l1;
 
-mask_stats::mask_stats(int beam_id, int nhistory) :
+typedef lock_guard<mutex> ulock;
+
+mask_stats::mask_stats(int beam_id, string where, int nhistory) :
     _beam_id(beam_id),
+    _where(where),
     _imeas(0),
     _maxmeas(nhistory)
 {}
@@ -18,11 +21,47 @@ mask_stats::~mask_stats() {
 void mask_stats::mask_count(const struct rf_pipelines::mask_counter_measurements& meas) {
     cout << "mask_stats: beam " << _beam_id << " got pos " << meas.pos << ": N samples masked: " << meas.nsamples_masked << "/" << meas.nsamples << "; n times " << meas.nt_masked << "/" << meas.nt << "; n freqs " << meas.nf_masked << "/" << meas.nf << endl;
 
-    if (_imeas < _maxmeas)
-        _meas.push_back(meas);
-    else
-        // ring buffer
-        _meas[_imeas] = meas;
-    _imeas++;
+    {
+        ulock l(_meas_mutex);
+        if (_imeas < _maxmeas)
+            _meas.push_back(meas);
+        else
+            // ring buffer
+            _meas[_imeas] = meas;
+        _imeas = (_imeas + 1) % _maxmeas;
+    }
 }
 
+unordered_map<string, float> mask_stats::get_stats(float history) {
+    unordered_map<string, float> stats;
+
+    // FIXME -- assume one sample per second!
+    int nsteps = (int)history;
+
+    float totsamp = 0;
+    float totmasked = 0;
+    float tot_t = 0;
+    float tot_tmasked = 0;
+    float tot_fmasked = 0;
+    {
+        ulock l(_meas_mutex);
+        if (nsteps > _meas.size())
+            nsteps = _meas.size();
+        int istart = (_imeas - nsteps + _maxmeas) % _maxmeas;
+        int iend = (istart + nsteps) % _maxmeas;
+        cout << "History: " << history << " imeas=" << _imeas << ", max="
+             << _maxmeas << " -> istart " << istart << ", iend " << iend << endl;
+        for (int i=istart; i<(istart + nsteps); i=(i + 1) % _maxmeas) {
+            totsamp += _meas[i].nsamples;
+            totmasked += _meas[i].nsamples_masked;
+            tot_t += _meas[i].nt;
+            tot_tmasked += _meas[i].nt_masked;
+            tot_fmasked += _meas[i].nf_masked;
+        }
+    }
+    stats["rfi_mask_pct_masked"] = 100. * totmasked / totsamp;
+    stats["rfi_mask_pct_t_masked"] = 100. * tot_tmasked / tot_t;
+    stats["rfi_mask_pct_f_masked"] = 100. * tot_fmasked / (float)nsteps;
+    return stats;
+}
+    

--- a/mask_stats.cpp
+++ b/mask_stats.cpp
@@ -1,0 +1,18 @@
+#include <iostream>
+#include <mask_stats.hpp>
+
+using namespace std;
+using namespace rf_pipelines;
+using namespace ch_frb_io;
+using namespace ch_frb_l1;
+
+mask_stats::mask_stats() {
+}
+
+mask_stats::~mask_stats() {
+}
+
+void mask_stats::mask_count(const struct rf_pipelines::mask_counter_measurements& meas) {
+    cout << "mask_stats: got pos " << meas.pos << ": N samples masked: " << meas.nsamples_masked << "/" << meas.nsamples << "; n times " << meas.nt_masked << "/" << meas.nt << "; n freqs " << meas.nf_masked << "/" << meas.nf << endl;
+}
+

--- a/mask_stats.hpp
+++ b/mask_stats.hpp
@@ -10,9 +10,15 @@ namespace ch_frb_l1 {
 
 class mask_stats : public rf_pipelines::mask_counter_callback {
 public:
-    mask_stats();
+    mask_stats(int beam_id, int nhistory=60);
     virtual void mask_count(const struct rf_pipelines::mask_counter_measurements& m);
     virtual ~mask_stats();
+    
+private:
+    int _beam_id;
+    std::vector<rf_pipelines::mask_counter_measurements> _meas;
+    int _imeas;
+    int _maxmeas;
 };
 
 }  // namespace ch_frb_l1

--- a/mask_stats.hpp
+++ b/mask_stats.hpp
@@ -1,0 +1,20 @@
+#ifndef _MASK_STATS_HPP
+#define _MASK_STATS_HPP
+
+#include <rf_pipelines.hpp>
+
+namespace ch_frb_l1 {
+#if 0
+}  // compiler pacifier
+#endif
+
+class mask_stats : public rf_pipelines::mask_counter_callback {
+public:
+    mask_stats();
+    virtual void mask_count(const struct rf_pipelines::mask_counter_measurements& m);
+    virtual ~mask_stats();
+};
+
+}  // namespace ch_frb_l1
+
+#endif

--- a/mask_stats.hpp
+++ b/mask_stats.hpp
@@ -1,6 +1,7 @@
 #ifndef _MASK_STATS_HPP
 #define _MASK_STATS_HPP
 
+#include <mutex>
 #include <rf_pipelines.hpp>
 
 namespace ch_frb_l1 {
@@ -10,12 +11,15 @@ namespace ch_frb_l1 {
 
 class mask_stats : public rf_pipelines::mask_counter_callback {
 public:
-    mask_stats(int beam_id, int nhistory=60);
+    mask_stats(int beam_id, std::string where="", int nhistory=60);
     virtual void mask_count(const struct rf_pipelines::mask_counter_measurements& m);
     virtual ~mask_stats();
-    
+    std::unordered_map<std::string, float> get_stats(float period);
+
+    const int _beam_id;
+    std::string _where;
 private:
-    int _beam_id;
+    std::mutex _meas_mutex;
     std::vector<rf_pipelines::mask_counter_measurements> _meas;
     int _imeas;
     int _maxmeas;

--- a/mask_stats.hpp
+++ b/mask_stats.hpp
@@ -25,6 +25,24 @@ private:
     int _maxmeas;
 };
 
+
+
+// Required to use a pair<int,string> as a key in an unordered_map.
+// From https://stackoverflow.com/questions/32685540/unordered-map-with-pair-as-key-not-compiling
+struct pair_hash {
+    template <class T1, class T2>
+    std::size_t operator () (const std::pair<T1,T2> &p) const {
+        auto h1 = std::hash<T1>{}(p.first);
+        auto h2 = std::hash<T2>{}(p.second);
+        return h1 ^ h2;  
+    }
+};
+
+// This is a map of <int beam_id, string where> to shared_ptr<mask_stats>
+// "where" is a property (specified in the JSON) of the mask_counter_transform
+typedef std::unordered_map<std::pair<int,std::string>, std::shared_ptr<ch_frb_l1::mask_stats>, pair_hash> mask_stats_map;
+
+
 }  // namespace ch_frb_l1
 
 #endif

--- a/mask_stats.hpp
+++ b/mask_stats.hpp
@@ -11,11 +11,12 @@ namespace ch_frb_l1 {
 
 class mask_stats : public rf_pipelines::mask_counter_callback {
 public:
-    mask_stats(int beam_id, std::string where="", int nhistory=60);
+    mask_stats(int beam_id, std::string where="", int nhistory=300);
     virtual void mask_count(const struct rf_pipelines::mask_counter_measurements& m);
     virtual ~mask_stats();
     std::unordered_map<std::string, float> get_stats(float period);
-
+    std::vector<rf_pipelines::mask_counter_measurements> get_all_measurements();
+    
     const int _beam_id;
     std::string _where;
 private:

--- a/rfi_configs/rfi_dstn.json
+++ b/rfi_configs/rfi_dstn.json
@@ -8,7 +8,7 @@
                     {
                         "class_name": "mask_counter", 
                         "nt_chunk": 1024,
-                        "name": "before_rfi"
+                        "where": "before_rfi"
                     },
                     {
                         "Df": 1, 
@@ -1095,7 +1095,7 @@
                     {
                         "class_name": "mask_counter", 
                         "nt_chunk": 1024,
-                        "name": "after_rfi"
+                        "where": "after_rfi"
                     }
                 ]
             }, 

--- a/rfi_configs/rfi_dstn.json
+++ b/rfi_configs/rfi_dstn.json
@@ -1,0 +1,1124 @@
+{
+    "class_name": "pipeline", 
+    "elements": [
+        {
+            "sub_pipeline": {
+                "class_name": "pipeline", 
+                "elements": [
+                    {
+                        "class_name": "mask_counter", 
+                        "nt_chunk": 1024,
+                        "name": "before_rfi"
+                    },
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": true, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 2048, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": true, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 6144, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": true, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 6144, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 6144, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 1, 
+                        "iter_sigma": 5, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 1, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 1, 
+                        "iter_sigma": 5, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 1, 
+                        "sigma": 5, 
+                        "two_pass": true, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 2, 
+                        "iter_sigma": 3, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 16, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_NONE"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 2, 
+                        "iter_sigma": 3, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 16, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": true, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 2048, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": true, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 6144, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": true, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 6144, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 6144, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 1, 
+                        "iter_sigma": 5, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 1, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 1, 
+                        "iter_sigma": 5, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 1, 
+                        "sigma": 5, 
+                        "two_pass": true, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 2, 
+                        "iter_sigma": 3, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 16, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_NONE"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 2, 
+                        "iter_sigma": 3, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 16, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": true, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 2048, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": true, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 6144, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": true, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 6144, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 6144, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 1, 
+                        "iter_sigma": 5, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 1, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 1, 
+                        "iter_sigma": 5, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 1, 
+                        "sigma": 5, 
+                        "two_pass": true, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 2, 
+                        "iter_sigma": 3, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 16, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_NONE"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 2, 
+                        "iter_sigma": 3, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 16, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": true, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 2048, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": true, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 6144, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": true, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 6144, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 6144, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 1, 
+                        "iter_sigma": 5, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 1, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 1, 
+                        "iter_sigma": 5, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 1, 
+                        "sigma": 5, 
+                        "two_pass": true, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 2, 
+                        "iter_sigma": 3, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 16, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_NONE"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 2, 
+                        "iter_sigma": 3, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 16, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": true, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 2048, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": true, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 6144, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": true, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 6144, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 6144, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 1, 
+                        "iter_sigma": 5, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 1, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 1, 
+                        "iter_sigma": 5, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 1, 
+                        "sigma": 5, 
+                        "two_pass": true, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 2, 
+                        "iter_sigma": 3, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 16, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_NONE"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 2, 
+                        "iter_sigma": 3, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 16, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": true, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 2048, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": true, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 6144, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": true, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 6144, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 6144, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 1, 
+                        "iter_sigma": 5, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 1, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 1, 
+                        "iter_sigma": 5, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 1, 
+                        "sigma": 5, 
+                        "two_pass": true, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 2, 
+                        "iter_sigma": 3, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 16, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_NONE"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 2, 
+                        "iter_sigma": 3, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 16, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "class_name": "polynomial_detrender", 
+                        "epsilon": 0.01, 
+                        "polydeg": 4, 
+                        "nt_chunk": 1024, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "class_name": "spline_detrender", 
+                        "epsilon": 0.0003, 
+                        "nt_chunk": 0, 
+                        "nbins": 6, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 2048, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 6144, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 6144, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 6144, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 1, 
+                        "iter_sigma": 5, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 1, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 1, 
+                        "iter_sigma": 5, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 1, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 2, 
+                        "iter_sigma": 3, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 16, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_NONE"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 2, 
+                        "iter_sigma": 3, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 16, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 2048, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 6144, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 6144, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 6144, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 1, 
+                        "iter_sigma": 5, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 1, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 1, 
+                        "iter_sigma": 5, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 1, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 2, 
+                        "iter_sigma": 3, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 16, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_NONE"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 2, 
+                        "iter_sigma": 3, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 16, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 2048, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 6144, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 6144, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 6144, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 1, 
+                        "iter_sigma": 5, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 1, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 1, 
+                        "iter_sigma": 5, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 1, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 2, 
+                        "iter_sigma": 3, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 16, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_NONE"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 2, 
+                        "iter_sigma": 3, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 16, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 2048, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 6144, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 6144, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 6144, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 1, 
+                        "iter_sigma": 5, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 1, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 1, 
+                        "iter_sigma": 5, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 1, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 2, 
+                        "iter_sigma": 3, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 16, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_NONE"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 2, 
+                        "iter_sigma": 3, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 16, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 2048, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 6144, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 6144, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 6144, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 1, 
+                        "iter_sigma": 5, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 1, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 1, 
+                        "iter_sigma": 5, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 1, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 2, 
+                        "iter_sigma": 3, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 16, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_NONE"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 2, 
+                        "iter_sigma": 3, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 16, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 2048, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 6144, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 6144, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "Df": 1, 
+                        "class_name": "std_dev_clipper", 
+                        "nt_chunk": 6144, 
+                        "Dt": 1, 
+                        "sigma": 3, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 1, 
+                        "iter_sigma": 5, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 1, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 1, 
+                        "iter_sigma": 5, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 1, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_TIME"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 2, 
+                        "iter_sigma": 3, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 16, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_NONE"
+                    }, 
+                    {
+                        "niter": 9, 
+                        "Df": 2, 
+                        "iter_sigma": 3, 
+                        "class_name": "intensity_clipper", 
+                        "nt_chunk": 1024, 
+                        "Dt": 16, 
+                        "sigma": 5, 
+                        "two_pass": false, 
+                        "axis": "AXIS_FREQ"
+                    }, 
+                    {
+                        "class_name": "mask_counter", 
+                        "nt_chunk": 1024,
+                        "name": "after_rfi"
+                    }
+                ]
+            }, 
+            "Df": 0, 
+            "class_name": "wi_sub_pipeline", 
+            "nds_out": 1, 
+            "nfreq_out": 1024, 
+            "w_cutoff": 0, 
+            "Dt": 0
+        }, 
+        {
+            "class_name": "polynomial_detrender", 
+            "epsilon": 0.01, 
+            "polydeg": 4, 
+            "nt_chunk": 1024, 
+            "axis": "AXIS_TIME"
+        }, 
+        {
+            "class_name": "spline_detrender", 
+            "epsilon": 0.0003, 
+            "nt_chunk": 0, 
+            "nbins": 6, 
+            "axis": "AXIS_FREQ"
+        }
+    ]
+}

--- a/rpc_client.py
+++ b/rpc_client.py
@@ -797,22 +797,49 @@ if __name__ == '__main__':
                 plt.title('Beam %i, %s' % (beam, where))
                 plt.ylim(-0.01, 1.01)
                 plt.savefig('masked-t-%i-%s.png' % (beam, where))
+
+                plt.clf()
+                plt.plot(hist, '.', alpha=0.01)
+                # Compute average in 1-second chunks
+                avgs = np.zeros(len(hist)//1000)
+                for i in range(len(avgs)):
+                    avgs[i] = np.mean(hist[i*1000:(i+1)*1000])
+                avgts = 500 + np.arange(len(avgs))*1000
+                plt.plot(avgts, avgs, 'b-')
+                plt.xlabel('Time (s)')
+                plt.ylabel('Fraction of masked samples')
+                plt.title('Beam %i, %s' % (beam, where))
+                plt.ylim(-0.01, 1.01)
+                plt.savefig('masked-t2-%i-%s.png' % (beam, where))
             allbeams = list(allbeams)
             allbeams.sort()
             for b in allbeams:
                 plt.clf()
-                for k,v in t.histories.items():
+                for ii,(k,v) in enumerate(t.histories.items()):
                     (beam,where) = k
                     if beam != b:
                         continue
                     hist = v
-                    plt.plot(hist, '-', label=where)
-                    plt.xlabel('Time (s)')
-                    plt.ylabel('Fraction of masked samples')
-                    plt.title('Beam %i' % (beam))
-                    plt.ylim(-0.01, 1.01)
-                    plt.legend()
-                    plt.savefig('masked-t-%i.png' % (beam))
+                    cc = 'brgm'[ii%4]
+                    # Compute average in 100-ms chunks
+                    avgs = np.zeros(len(hist)//100)
+                    for i in range(len(avgs)):
+                        avgs[i] = np.mean(hist[i*100:(i+1)*100])
+                    avgts = 50 + np.arange(len(avgs))*100
+                    plt.plot(avgts, avgs, '.', alpha=0.1, color=cc, label=where + ' (100 ms avg)')
+                    #plt.plot(hist, '.', alpha=0.1, color=cc, label=where)
+                    # Compute average in 1-second chunks
+                    avgs = np.zeros(len(hist)//1000)
+                    for i in range(len(avgs)):
+                        avgs[i] = np.mean(hist[i*1000:(i+1)*1000])
+                    avgts = 500 + np.arange(len(avgs))*1000
+                    plt.plot(avgts, avgs, '-', color=cc, label=where + ' (1 s avg)')
+                plt.xlabel('Time (s)')
+                plt.ylabel('Fraction of masked samples')
+                plt.title('Beam %i' % (beam))
+                plt.ylim(-0.01, 1.01)
+                plt.legend()
+                plt.savefig('masked-t-%i.png' % (beam))
 
         doexit = True
 

--- a/rpc_client.py
+++ b/rpc_client.py
@@ -115,11 +115,11 @@ class MaskedFrequencies(object):
         #print('Masked frequencies: got ', msgpack)
         self.histories = {}
         for m in msgpack:
-            (beam, where, hist) = m
+            (beam, where, nt, hist) = m
             print('Where:', where, type(where))
             where = where.decode()
-            self.histories[(beam, where)] = np.array(hist)
-            
+            self.histories[(beam, where)] = np.array(hist).astype(np.float32) / nt
+
 class PacketRate(object):
     def __init__(self, msgpack):
         self.start = msgpack[0]
@@ -735,7 +735,8 @@ if __name__ == '__main__':
             for k,v in f.histories.items():
                 (beam,where) = k
                 hist = v
-                print('Beam', beam, 'at', where, ':', hist.shape)
+                print('Beam', beam, 'at', where, ':', hist.shape, hist.dtype,
+                      hist.min(), hist.max())
                 import pylab as plt
                 plt.clf()
                 plt.imshow(hist, interpolation='nearest', origin='lower',

--- a/rpc_client.py
+++ b/rpc_client.py
@@ -755,6 +755,11 @@ if __name__ == '__main__':
             print('Got rate:', r)
         doexit = True
 
+    if opt.masked_freqs or opt.masked_times:
+        import matplotlib
+        matplotlib.use('Agg')
+        import pylab as plt
+
     if opt.masked_freqs:
         freqs = client.get_masked_frequencies()
         print('Received masked frequencies:')
@@ -766,7 +771,6 @@ if __name__ == '__main__':
                 hist = v
                 print('Beam', beam, 'at', where, ':', hist.shape, hist.dtype,
                       hist.min(), hist.max())
-                import pylab as plt
                 plt.clf()
                 plt.imshow(hist, interpolation='nearest', origin='lower',
                            vmin=0, vmax=1, cmap='gray', aspect='auto')
@@ -777,7 +781,6 @@ if __name__ == '__main__':
         doexit = True
 
     if opt.masked_times:
-        import pylab as plt
         times = client.get_masked_times()
         for t in times:
             allbeams = set()

--- a/test-l1-rpc.cpp
+++ b/test-l1-rpc.cpp
@@ -111,7 +111,7 @@ int main(int argc, char** argv) {
     stream->start_stream();
 
     prometheus_ip = prometheus_ip + to_string(prometheus_port);
-    vector<shared_ptr<ch_frb_l1::mask_stats> > ms;
+    ch_frb_l1::mask_stats_map ms;
     shared_ptr<L1PrometheusServer> prometheus_server =
         start_prometheus_server(prometheus_ip, stream, ms);
     if (!prometheus_server) {

--- a/test-l1-rpc.cpp
+++ b/test-l1-rpc.cpp
@@ -128,7 +128,7 @@ int main(int argc, char** argv) {
         port = "tcp://127.0.0.1:" + to_string(portnum);
 
     chlog("Starting RPC server on port " << port);
-    L1RpcServer rpc(stream, port);
+    L1RpcServer rpc(stream, ms, port);
     std::thread rpc_thread = rpc.start();
 
     std::random_device rd;

--- a/test-l1-rpc.cpp
+++ b/test-l1-rpc.cpp
@@ -111,7 +111,7 @@ int main(int argc, char** argv) {
     stream->start_stream();
 
     prometheus_ip = prometheus_ip + to_string(prometheus_port);
-    shared_ptr<ch_frb_l1::mask_stats> ms;
+    vector<shared_ptr<ch_frb_l1::mask_stats> > ms;
     shared_ptr<L1PrometheusServer> prometheus_server =
         start_prometheus_server(prometheus_ip, stream, ms);
     if (!prometheus_server) {

--- a/test-l1-rpc.cpp
+++ b/test-l1-rpc.cpp
@@ -111,8 +111,9 @@ int main(int argc, char** argv) {
     stream->start_stream();
 
     prometheus_ip = prometheus_ip + to_string(prometheus_port);
+    shared_ptr<ch_frb_l1::mask_stats> ms;
     shared_ptr<L1PrometheusServer> prometheus_server =
-        start_prometheus_server(prometheus_ip, stream);
+        start_prometheus_server(prometheus_ip, stream, ms);
     if (!prometheus_server) {
         return -1;
     }

--- a/test-packet-rates.cpp
+++ b/test-packet-rates.cpp
@@ -109,7 +109,7 @@ int main(int argc, char** argv) {
         chlog("Starting RPC server on port " << rpc_addr);
 
         string pro_addr = to_string(prometheus_port + i);
-        vector<shared_ptr<ch_frb_l1::mask_stats> > ms;
+        ch_frb_l1::mask_stats_map ms;
         shared_ptr<L1PrometheusServer> pro = start_prometheus_server(pro_addr, stream, ms);
         if (!pro) {
             return -1;

--- a/test-packet-rates.cpp
+++ b/test-packet-rates.cpp
@@ -100,7 +100,8 @@ int main(int argc, char** argv) {
         streams.push_back(stream);
         
         string rpc_addr = "tcp://127.0.0.1:" + to_string(rpc_port + i);
-        shared_ptr<L1RpcServer> rpc = make_shared<L1RpcServer>(stream, rpc_addr);
+        ch_frb_l1::mask_stats_map ms;
+        shared_ptr<L1RpcServer> rpc = make_shared<L1RpcServer>(stream, ms, rpc_addr);
         rpcs.push_back(rpc);
         rpc_threads[i] = rpc->start();
         
@@ -109,7 +110,6 @@ int main(int argc, char** argv) {
         chlog("Starting RPC server on port " << rpc_addr);
 
         string pro_addr = to_string(prometheus_port + i);
-        ch_frb_l1::mask_stats_map ms;
         shared_ptr<L1PrometheusServer> pro = start_prometheus_server(pro_addr, stream, ms);
         if (!pro) {
             return -1;

--- a/test-packet-rates.cpp
+++ b/test-packet-rates.cpp
@@ -109,7 +109,8 @@ int main(int argc, char** argv) {
         chlog("Starting RPC server on port " << rpc_addr);
 
         string pro_addr = to_string(prometheus_port + i);
-        shared_ptr<L1PrometheusServer> pro = start_prometheus_server(pro_addr, stream);
+        shared_ptr<ch_frb_l1::mask_stats> ms;
+        shared_ptr<L1PrometheusServer> pro = start_prometheus_server(pro_addr, stream, ms);
         if (!pro) {
             return -1;
         }

--- a/test-packet-rates.cpp
+++ b/test-packet-rates.cpp
@@ -109,7 +109,7 @@ int main(int argc, char** argv) {
         chlog("Starting RPC server on port " << rpc_addr);
 
         string pro_addr = to_string(prometheus_port + i);
-        shared_ptr<ch_frb_l1::mask_stats> ms;
+        vector<shared_ptr<ch_frb_l1::mask_stats> > ms;
         shared_ptr<L1PrometheusServer> pro = start_prometheus_server(pro_addr, stream, ms);
         if (!pro) {
             return -1;


### PR DESCRIPTION
- adds mask_stats class that collects data from the rf_pipelines mask_counter_transform class
- adds prometheus metrics on mask_stats
- adds an RPC call to retrieve the masked frequencies history from mask_stats
- ch-frb-simulate-l0: add option to stream data from msgpack files
- ch-frb-l1: add -i option to ignore end-of-stream markers