### PR TITLE
Get frame0 time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ rpc-client: rpc_client.o
 	$(CPP) -o $@ $^ $(CPP_LFLAGS) -lch_frb_io -lzmq
 
 ch-frb-l1: ch-frb-l1.o file_utils.o yaml_paramfile.o $(L1_OBJS) $(CIVET_OBJS)
-	$(CPP) -o $@ $^ $(CPP_LFLAGS) -lrf_pipelines -lbonsai -lch_frb_io -lrf_kernels -lzmq -lyaml-cpp -ljsoncpp -ldl
+	$(CPP) -o $@ $^ $(CPP_LFLAGS) -lrf_pipelines -lbonsai -lch_frb_io -lrf_kernels -lzmq -lyaml-cpp -ljsoncpp -ldl -lcurl
 
 sim-l0-set: sim-l0-set.cpp l0-sim.cpp
 	$(CPP) -o $@ $^ $(CPP_CFLAGS) $(CPP_LFLAGS) -lch_frb_io

--- a/ch-frb-l1.cpp
+++ b/ch-frb-l1.cpp
@@ -28,6 +28,8 @@
 #include <sys/socket.h>
 #include <ifaddrs.h>
 
+#include <curl/curl.h>
+
 #include <ch_frb_io_internals.hpp>
 #include <rf_pipelines.hpp>
 #include <bonsai.hpp>
@@ -118,6 +120,9 @@ struct l1_config
     vector<string> prometheus_address;
     // Optional chlog logging server address
     string logger_address;
+
+    // Optional URL to get frame0-ctime
+    string frame0_url;
 
     // A vector of length nbeams, containing the beam_ids that will be processed on this L1 server.
     // It is currently assumed that these are known in advance and never change!
@@ -361,6 +366,7 @@ l1_config::l1_config(int argc, char **argv)
     this->rpc_address = p.read_vector<string> ("rpc_address");
     this->prometheus_address = p.read_vector<string> ("prometheus_address");
     this->logger_address = p.read_scalar<string> ("logger_address", "");
+    this->frame0_url = p.read_scalar<string> ("frame0_url", "");
     this->slow_kernels = p.read_scalar<bool> ("slow_kernels", false);
     this->unassembled_ringbuf_nsamples = p.read_scalar<int> ("unassembled_ringbuf_nsamples", 4096);
     this->assembled_ringbuf_nsamples = p.read_scalar<int> ("assembled_ringbuf_nsamples", 8192);
@@ -912,12 +918,16 @@ struct l1_server {
     vector<std::thread> rpc_threads;
     vector<std::thread> dedispersion_threads;
 
+    string frame0_txt;
+    int64_t frame0_nano;
+
     // The constructor reads the configuration files, does a lot of sanity checks,
     // but does not initialize any "heavyweight" data structures.
     l1_server(int argc, char **argv);
 
     // These methods incrementally construct the "heavyweight" data structures.
     void start_logging();
+    void fetch_frame0();
     void spawn_l1b_subprocesses();
     void make_output_devices();
     void make_memory_slab_pools();
@@ -1246,7 +1256,6 @@ void l1_server::make_prometheus_servers()
     }
 }
 
-       
 void l1_server::spawn_dedispersion_threads()
 {
     if (dedispersion_threads.size())
@@ -1354,12 +1363,78 @@ void l1_server::print_statistics()
 
 // -------------------------------------------------------------------------------------------------
 
+static size_t
+CurlWriteMemoryCallback(void *contents, size_t size, size_t nmemb, void *userp)
+{
+    size_t realsize = size * nmemb;
+    l1_server* l1 = (l1_server*)userp;
+    l1->frame0_txt += string((char*)contents, realsize);
+    return realsize;
+}
+
+void l1_server::fetch_frame0()
+{
+    if (config.frame0_url.size() == 0) {
+        cout << "No 'frame0_url' in config file; skipping." << endl;
+        return;
+    }
+    CURL *curl_handle;
+    CURLcode res;
+    // init the curl session
+    curl_handle = curl_easy_init();
+    // specify URL to get
+    curl_easy_setopt(curl_handle, CURLOPT_URL, config.frame0_url.c_str());
+    // set timeout
+    curl_easy_setopt(curl_handle, CURLOPT_TIMEOUT_MS, 3000);
+    // set received-data callback
+    frame0_txt = "";
+    curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION,
+                     CurlWriteMemoryCallback);
+    curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, (void *)this);
+    // curl!
+    cout << "Fetching frame0_time from " << config.frame0_url << endl;
+    res = curl_easy_perform(curl_handle);
+    if (res != CURLE_OK) {
+        cout << "Fetch_frame0 failed: " << string(curl_easy_strerror(res)) << endl;
+        return;
+    }
+    curl_easy_cleanup(curl_handle);
+
+    cout << "Received frame0 text: " << frame0_txt << endl;
+    Json::Reader frame0_reader;
+    Json::Value frame0_json;
+    if (!frame0_reader.parse(frame0_txt, frame0_json)) {
+        cout << "ch-frb-l1: failed to parse 'frame0' string: '"
+             << frame0_txt << "'" << endl;
+        return;
+    }
+    cout << "Parsed: " << frame0_json << endl;
+    if (!frame0_json.isObject()) {
+        cout << "ch-frb-l1: 'frame0' was not a JSON 'Object' as expected" << endl;
+        return;
+    }
+    string key = "frame0_nano";
+    if (!frame0_json.isMember(key)) {
+        cout << "ch-frb-l1: 'frame0' did not contain key '" << key << "'" << endl;
+        return;
+    }
+    const Json::Value v = frame0_json[key];
+    if (!v.isIntegral()) {
+        cout << "ch-frb-l1: expected 'frame0[frame0_nano]' to be integral." << endl;
+        return;
+    }
+    frame0_nano = v.asInt64();
+    cout << "Found frame0_nano: " << frame0_nano << endl;
+}
 
 int main(int argc, char **argv)
 {
+    curl_global_init(CURL_GLOBAL_ALL);
+
     l1_server server(argc, argv);
 
     server.start_logging();
+    server.fetch_frame0();
     server.spawn_l1b_subprocesses();
     server.make_output_devices();
     server.make_memory_slab_pools();
@@ -1371,5 +1446,6 @@ int main(int argc, char **argv)
     server.join_all_threads();
     server.print_statistics();
 
+    curl_global_cleanup();
     return 0;
 }

--- a/ch-frb-l1.cpp
+++ b/ch-frb-l1.cpp
@@ -919,7 +919,7 @@ struct l1_server {
     vector<std::thread> dedispersion_threads;
 
     string frame0_txt;
-    int64_t frame0_nano;
+    uint64_t frame0_nano;
 
     // The constructor reads the configuration files, does a lot of sanity checks,
     // but does not initialize any "heavyweight" data structures.
@@ -1179,6 +1179,7 @@ void l1_server::make_input_streams()
 	ini_params.nt_per_packet = config.nt_per_packet;
 	ini_params.fpga_counts_per_sample = config.fpga_counts_per_sample;
 	ini_params.stream_id = istream + 1;   // +1 here since first NFS mount is /frb-archive-1, not /frb-archive-0
+        ini_params.frame0_nano = frame0_nano;
 	ini_params.force_fast_kernels = !config.slow_kernels;
 	ini_params.force_reference_kernels = config.slow_kernels;
 	ini_params.deliberately_crash = config.deliberately_crash;
@@ -1423,7 +1424,7 @@ void l1_server::fetch_frame0()
         cout << "ch-frb-l1: expected 'frame0[frame0_nano]' to be integral." << endl;
         return;
     }
-    frame0_nano = v.asInt64();
+    frame0_nano = v.asUInt64();
     cout << "Found frame0_nano: " << frame0_nano << endl;
 }
 


### PR DESCRIPTION
- if "frame0_url" is added to the config file, then libcurl is used to fetch a JSON string from that URL upon L1 startup.  Eg, 

frame0_url: "http://carillon.chime:54321/get-frame0-time"

- that frame0_nano value is propagated into the intensity_network_streams -> assembled_chunks -> L1b opaque_context

- adds this field to the msgpack format (in a backward-compatible way)


