### PR TITLE
Prepare environment for prometheus_client multiprocess mode

### DIFF
--- a/ch-frb-l1-dispatch.sh
+++ b/ch-frb-l1-dispatch.sh
@@ -47,4 +47,17 @@ export PATH=/usr/local/bin:/usr/bin:/bin:/home/l1operator/${VERSION}/bin
 
 cd /home/l1operator/${VERSION}/ch_frb_l1
 
+# Environment variable "prometheus_multiproc_dir" is required for the
+# Prometheus Python client to operate in the multi-process mode. (See
+# https://github.com/prometheus/client_python#multiprocess-mode-gunicorn)
+# To avoid metric pollution across execution, we use a unique directory
+# per run, and remove it afterwards.
+export prometheus_multiproc_dir=$(mktemp --dir --tmp "l1b_metrics.XXXX")
+
 ./ch-frb-l1 l1_configs/l1_production_8beam_rack${rack}_node${node}.yaml ../ch_frb_rfi/json_files/rfi_16k/${RFI_CONFIG} /data/bonsai_configs/${BONSAI_CONFIG} L1b_config_site.yaml
+
+# cleanup Prometheus multiproc setup
+if [ -d "${prometheus_multiproc_dir}" ]; then
+    rm "${prometheus_multiproc_dir}"/*.db
+    rmdir "${prometheus_multiproc_dir}"
+fi

--- a/ch-frb-l1-dispatch.sh
+++ b/ch-frb-l1-dispatch.sh
@@ -54,6 +54,20 @@ cd /home/l1operator/${VERSION}/ch_frb_l1
 # per run, and remove it afterwards.
 export prometheus_multiproc_dir=$(mktemp --dir --tmp "l1b_metrics.XXXX")
 
+# Run a separate Python process just for reporting shared metrics
+cat <<EOF | python & <<EOF
+import prometheus_client as prom
+import prometheus_client.multiprocess as mp
+import time
+
+registry = prom.CollectorRegistry()
+mp.MultiProcessCollector(registry)
+prom.start_http_server(8080, registry=registry)
+
+while True:
+  time.sleep(10)
+EOF
+
 ./ch-frb-l1 l1_configs/l1_production_8beam_rack${rack}_node${node}.yaml ../ch_frb_rfi/json_files/rfi_16k/${RFI_CONFIG} /data/bonsai_configs/${BONSAI_CONFIG} L1b_config_site.yaml
 
 # cleanup Prometheus multiproc setup

--- a/ch-frb-l1.cpp
+++ b/ch-frb-l1.cpp
@@ -1206,12 +1206,11 @@ void l1_server::spawn_l1b_subprocesses()
     }
 
     for (int ibeam = 0; ibeam < config.nbeams; ibeam++) {
-	// L1b command line is: <l1_executable> <l1b_config> <beam_id> <worker_id>
+	// L1b command line is: <l1_executable> <l1b_config> <beam_id>
 	vector<string> l1b_command_line = {
 	    config.l1b_executable_filename,
 	    config.l1b_config_filename,
-	    std::to_string(config.beam_ids[ibeam]),
-      std::to_string(ibeam)
+	    std::to_string(config.beam_ids[ibeam])
 	};
 	
 	bonsai::trigger_pipe::initializer l1b_initializer;

--- a/ch-frb-l1.cpp
+++ b/ch-frb-l1.cpp
@@ -1206,11 +1206,12 @@ void l1_server::spawn_l1b_subprocesses()
     }
 
     for (int ibeam = 0; ibeam < config.nbeams; ibeam++) {
-	// L1b command line is: <l1_executable> <l1b_config> <beam_id>
+	// L1b command line is: <l1_executable> <l1b_config> <beam_id> <worker_id>
 	vector<string> l1b_command_line = {
 	    config.l1b_executable_filename,
 	    config.l1b_config_filename,
-	    std::to_string(config.beam_ids[ibeam])
+	    std::to_string(config.beam_ids[ibeam]),
+      std::to_string(ibeam)
 	};
 	
 	bonsai::trigger_pipe::initializer l1b_initializer;


### PR DESCRIPTION
Environment variable "prometheus_multiproc_dir" is required for the Prometheus Python client to operate in the multi-process mode (see [documentation][1]), which it will following PR CHIMEFRB/ch_frb_L1b#9.

To avoid metric pollution across executions, we use a unique directory per run, and remove it afterwards.

[1]: https://github.com/prometheus/client_python#multiprocess-mode-gunicorn