### PR TITLE
Add RPC watchdog mechanism

### DIFF
--- a/ch-frb-l1.cpp
+++ b/ch-frb-l1.cpp
@@ -1175,10 +1175,13 @@ void l1_server::make_rpc_servers()
                                              latency_monitors_post[istream * nbeams_per_stream + ib]));
         }
 
+        rpc_servers_alive.push_back(make_shared<std::atomic<bool> >());
         if (heavy) {
             vector<shared_ptr<rf_pipelines::intensity_injector> > empty_inj;
             // Light-weight RPC server gets no injectors
             ostringstream name;
+            heavy_rpc_servers_alive.push_back(make_shared<std::atomic<bool> >());
+
             name << "Light-weight RPC server #" << (istream+1)
                  << "(" << config.rpc_address[istream] << ")";
             rpc_servers[istream] = make_shared<L1RpcServer> (input_streams[istream], empty_inj, mask_stats_maps[istream], rpc_servers_alive[istream], rpc_bonsais, false, config.rpc_address[istream], command_line, rpc_latency, name.str());

--- a/ch_frb_l1.hpp
+++ b/ch_frb_l1.hpp
@@ -195,6 +195,8 @@ struct l1_server {
     std::vector<std::shared_ptr<mask_stats_map> > mask_stats_maps;
     std::vector<std::shared_ptr<L1RpcServer>> rpc_servers;
     std::vector<std::shared_ptr<L1RpcServer>> heavy_rpc_servers;
+    std::vector<std::shared_ptr<std::atomic<bool>>> rpc_servers_alive;
+    std::vector<std::shared_ptr<std::atomic<bool>>> heavy_rpc_servers_alive;
     std::vector<std::shared_ptr<L1PrometheusServer>> prometheus_servers;
     std::vector<std::shared_ptr<rf_pipelines::intensity_injector> > injectors;
     std::vector<std::thread> rpc_threads;

--- a/l1-prometheus.cpp
+++ b/l1-prometheus.cpp
@@ -263,7 +263,7 @@ public:
                     string where;
                     unordered_map<string, float> mstats;
                     std::tie(stream_ibeam, where, mstats) = maskstats[ib];
-                    if (stream_ibeam >= beams.size())
+                    if (stream_ibeam >= int(beams.size()))
                         continue;
                     int beam_id = beams[stream_ibeam];
                     const char* key = ms5[i].key;

--- a/l1-rpc.cpp
+++ b/l1-rpc.cpp
@@ -275,6 +275,7 @@ void inject_data_request::swap(rf_pipelines::intensity_injector::inject_args& de
 L1RpcServer::L1RpcServer(shared_ptr<ch_frb_io::intensity_network_stream> stream,
                          vector<shared_ptr<rf_pipelines::intensity_injector> > injectors,
                          shared_ptr<const ch_frb_l1::mask_stats_map> ms,
+                         shared_ptr<std::atomic<bool> > is_alive,
                          vector<shared_ptr<const bonsai::dedisperser> > bonsais,
                          bool heavy,
                          const string &port,
@@ -284,8 +285,9 @@ L1RpcServer::L1RpcServer(shared_ptr<ch_frb_io::intensity_network_stream> stream,
                          zmq::context_t *ctx
                          ) :
     _command_line(cmdline),
-    _name(name),
     _heavy(heavy),
+    _name(name),
+    _is_alive(is_alive),
     _ctx(ctx ? ctx : new zmq::context_t()),
     _created_ctx(ctx == NULL),
     _frontend(*_ctx, ZMQ_ROUTER),
@@ -369,6 +371,9 @@ void L1RpcServer::run() {
     while (!is_shutdown()) {
 	_check_backend_queue();
 
+        // Set watchdog!
+        _is_alive->store(true);
+        
         zmq::message_t client;
         zmq::message_t msg;
 

--- a/l1-rpc.cpp
+++ b/l1-rpc.cpp
@@ -284,9 +284,9 @@ L1RpcServer::L1RpcServer(shared_ptr<ch_frb_io::intensity_network_stream> stream,
                          const string &name,
                          zmq::context_t *ctx
                          ) :
+    _name(name),
     _command_line(cmdline),
     _heavy(heavy),
-    _name(name),
     _is_alive(is_alive),
     _ctx(ctx ? ctx : new zmq::context_t()),
     _created_ctx(ctx == NULL),

--- a/l1-rpc.hpp
+++ b/l1-rpc.hpp
@@ -39,6 +39,7 @@ public:
     L1RpcServer(std::shared_ptr<ch_frb_io::intensity_network_stream> stream,
                 std::vector<std::shared_ptr<rf_pipelines::intensity_injector> > injectors,
                 std::shared_ptr<const ch_frb_l1::mask_stats_map> maskstats,
+                std::shared_ptr<std::atomic<bool> > is_alive,
                 std::vector<std::shared_ptr<const bonsai::dedisperser> > bonsais =
                 std::vector<std::shared_ptr<const bonsai::dedisperser> >(),
                 bool heavy = true,
@@ -139,6 +140,9 @@ private:
 
     // Name
     std::string _name;
+
+    // Watchdog
+    std::shared_ptr<std::atomic<bool> > _is_alive;
 
     // ZeroMQ context
     zmq::context_t* _ctx;

--- a/l1-rpc.hpp
+++ b/l1-rpc.hpp
@@ -75,6 +75,9 @@ public:
     // server's *other* stream/port!
     void reset_beams();
 
+    // Name
+    const std::string _name;
+
 protected:
     // responds to the given RPC request, either sending immediate
     // reply or queuing work for worker threads.
@@ -130,16 +133,13 @@ protected:
 
     std::shared_ptr<const bonsai::dedisperser> _get_bonsai_for_beam(int beam);
     std::shared_ptr<rf_pipelines::intensity_injector> _get_injector_for_beam(int beam);
-    
+
 private:
     // The command line that launched this L1 process
     std::string _command_line;
 
     // Are we doing heavy-weight RPCs?
     bool _heavy;
-
-    // Name
-    std::string _name;
 
     // Watchdog
     std::shared_ptr<std::atomic<bool> > _is_alive;

--- a/site/Makefile.local.dstn_laptop
+++ b/site/Makefile.local.dstn_laptop
@@ -10,7 +10,8 @@ INCDIR=$(HOME)/chime/include
 BINDIR=$(HOME)/chime/bin
 
 # Read-only location of python header files
-PYTHON_INCDIR=/usr/include/python2.7
+#PYTHON_INCDIR=/usr/include/python2.7
+PYTHON_INCDIR=/usr/local/python2.7-include
 NUMPY_INCDIR=/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/numpy/core/include
 
 HDF5_INC_DIR=/usr/local/include

--- a/test-l1-rpc.cpp
+++ b/test-l1-rpc.cpp
@@ -135,7 +135,8 @@ int main(int argc, char** argv) {
     chlog("Starting RPC server on port " << port);
     vector<shared_ptr<const bonsai::dedisperser> > bonsais;
     std::vector<std::shared_ptr<rf_pipelines::intensity_injector> > inj;
-    L1RpcServer rpc(stream, inj, ms, bonsais, true, port);
+    std::shared_ptr<std::atomic<bool>> is_alive;
+    L1RpcServer rpc(stream, inj, ms, is_alive, bonsais, true, port);
     std::thread rpc_thread = rpc.start();
 
     std::random_device rd;

--- a/test-packet-rates.cpp
+++ b/test-packet-rates.cpp
@@ -102,7 +102,8 @@ int main(int argc, char** argv) {
         std::vector<std::shared_ptr<rf_pipelines::intensity_injector> > inj;
         shared_ptr<ch_frb_l1::mask_stats_map> ms = make_shared<ch_frb_l1::mask_stats_map>();
         vector<shared_ptr<const bonsai::dedisperser> > bonsais;
-        shared_ptr<L1RpcServer> rpc = make_shared<L1RpcServer>(stream, inj, ms, bonsais, true, rpc_addr);
+        std::shared_ptr<std::atomic<bool>> is_alive;
+        shared_ptr<L1RpcServer> rpc = make_shared<L1RpcServer>(stream, inj, ms, is_alive, bonsais, true, rpc_addr);
         rpcs.push_back(rpc);
         rpc_threads[i] = rpc->start();
         


### PR DESCRIPTION
The RPC threads can crash silently without bringing down the rest of L1, and that is Bad.  This PR adds watchdog flags that the RPC threads set, while the "main" thread resets and then checks after 5 seconds.  If the RPC threads are found to be dead, the whole L1 process will be terminated.
