### PR TITLE
Add logic to handle two chime_slow_pulsar_writer objects

### DIFF
--- a/ch-frb-l1.cpp
+++ b/ch-frb-l1.cpp
@@ -623,14 +623,19 @@ void dedispersion_thread_context::_init_mask_counters(const shared_ptr<rf_pipeli
 
 static void find_slow_pulsar_writer(shared_ptr<rf_pipelines::chime_slow_pulsar_writer> &sp_writer,
 				    const shared_ptr<rf_pipelines::pipeline_object> &pipe,
-				    int level)
+				    int level, const std::string &target_name)
 {
     shared_ptr<rf_pipelines::chime_slow_pulsar_writer> sp = dynamic_pointer_cast<rf_pipelines::chime_slow_pulsar_writer> (pipe);
     
-    if (!sp)
+    if (!sp) {
         return;
-    if (sp_writer)
-	throw runtime_error("fatal: multiple chime_slow_pulsar_writers found in chain");
+    }
+    if (sp->name != target_name) {
++       return;
+    }
+    if (sp_writer) {
+	    throw runtime_error("fatal: multiple chime_slow_pulsar_writers found in chain");
+    }
 
     sp_writer = sp;
 }
@@ -700,27 +705,46 @@ void dedispersion_thread_context::_thread_main() const
     //     throw runtime_error("ch-frb-l1: need exactly one chime_mask_counter in the RFI config JSON file, or else RFI masks cannot be captured.");
     // }
 
-    shared_ptr<rf_pipelines::chime_slow_pulsar_writer> sp_writer;
+    shared_ptr<rf_pipelines::chime_slow_pulsar_writer> sp_writer_champss;
+    shared_ptr<rf_pipelines::chime_slow_pulsar_writer> sp_writer_slow;
 
     rf_pipelines::visit_pipeline(std::bind(find_slow_pulsar_writer,
-					   std::ref(sp_writer),
+					   std::ref(sp_writer_champss),
 					   std::placeholders::_1,
-					   std::placeholders::_2),
+					   std::placeholders::_2, "champss"),
+				 rfi_chain);
+    rf_pipelines::visit_pipeline(std::bind(find_slow_pulsar_writer,
+					   std::ref(sp_writer_slow),
+					   std::placeholders::_1,
+					   std::placeholders::_2, "slow"),
 				 rfi_chain);
 
     // FIXME should make it a configurable option to run server with/without the slow_pulsar_writer.
-    if (!sp_writer)
-	throw runtime_error("ch-frb-l1: fatal: expected RFI json file to contain a chime_slow_pulsar_writer");
+    if (!sp_writer_champss) {
+        throw runtime_error("ch-frb-l1: fatal: expected RFI json file to contain a chime_slow_pulsar_writer for CHAMPSS");
+    }
+    if (!sp_writer_slow) {
+        throw runtime_error("ch-frb-l1: fatal: expected RFI json file to contain a chime_slow_pulsar_writer for Slow");
+    }
 
-    rf_pipelines::chime_slow_pulsar_writer::real_time_state sp_rts;
+    rf_pipelines::chime_slow_pulsar_writer::real_time_state sp_rts_champss;
+    rf_pipelines::chime_slow_pulsar_writer::real_time_state sp_rts_slow;
+
     // don't bother finding the beam id anymore; other checks make sure the assignment
     // is correct.
-    sp_rts.memory_pool = sp->ini_params.memory_pool;
-    sp_rts.output_devices = make_shared<ch_frb_io::output_device_pool> (sp->ini_params.output_devices);
-    sp_rts.chime_stream = sp;
 
-    sp_writer->init_real_time_state(sp_rts);
-    sp_writer_hash->set(stream_ibeam, sp_writer);
+    sp_rts_champss.memory_pool = sp->ini_params.memory_pool;
+    sp_rts_champss.output_devices = make_shared<ch_frb_io::output_device_pool> (sp->ini_params.output_devices);
+    sp_rts_champss.chime_stream = sp;
+    sp_rts_slow.memory_pool = sp->ini_params.memory_pool;
+    sp_rts_slow.output_devices = make_shared<ch_frb_io::output_device_pool> (sp->ini_params.output_devices);
+    sp_rts_slow.chime_stream = sp;
+
+    sp_writer_champss->init_real_time_state(sp_rts_champss);
+    sp_writer_slow->init_real_time_state(sp_rts_slow);
+
+    sp_writer_hash->set(stream_ibeam, "champss", sp_writer_champss);
+    sp_writer_hash->set(stream_ibeam, "slow", sp_writer_slow);
 	
     _init_mask_counters(rfi_chain, stream_ibeam);
 

--- a/ch-frb-l1.cpp
+++ b/ch-frb-l1.cpp
@@ -631,7 +631,7 @@ static void find_slow_pulsar_writer(shared_ptr<rf_pipelines::chime_slow_pulsar_w
         return;
     }
     if (sp->name != target_name) {
-+       return;
+        return;
     }
     if (sp_writer) {
 	    throw runtime_error("fatal: multiple chime_slow_pulsar_writers found in chain");

--- a/l1-rpc.cpp
+++ b/l1-rpc.cpp
@@ -661,6 +661,7 @@ int L1RpcServer::_handle_request(zmq::message_t& client, const zmq::message_t& r
         auto ntime = oh.get().via.array.ptr[2].as<int>();
         auto nbins = oh.get().via.array.ptr[3].as<int>();
         std::shared_ptr<std::string> base_path(new std::string(oh.get().via.array.ptr[4].as<std::string>()));
+        std::shared_ptr<std::string> source(new std::string(oh.get().via.array.ptr[5].as<std::string>()));
 
         const size_t nbeams = this->_stream->ini_params.nbeams;
         int target_ibeam = -1;
@@ -680,12 +681,13 @@ int L1RpcServer::_handle_request(zmq::message_t& client, const zmq::message_t& r
 	string result = "failure: target beam_id not found!";
 
         if (target_ibeam != -1) {
-	    this->_slow_pulsar_writer_hash->get(target_ibeam)
-		->set_params(target_beam, nfreq, ntime, nbins, base_path);
+	    this->_slow_pulsar_writer_hash->get(target_ibeam, *source)
++       ->set_params(target_beam, nfreq, ntime, nbins, base_path, source);
 			     
 	    chlog("Pulsar writer parameter update" << std::endl << "\tnfreq_out: " << nfreq
-		  << std::endl <<  "\tntime_out: " << ntime << std::endl << "\tnbins: " 
-		  << nbins << std::endl << "base_path: " << *base_path << std::endl);
+                << std::endl <<  "\tntime_out: " << ntime << std::endl << "\tnbins: " 
+                << nbins << std::endl << "base_path: " << *base_path << std::endl << "source: " 
+                << *source << std::endl);
 
 	    result = "parameters successfully applied to slow pulsar writer";
         }

--- a/l1-rpc.cpp
+++ b/l1-rpc.cpp
@@ -682,7 +682,7 @@ int L1RpcServer::_handle_request(zmq::message_t& client, const zmq::message_t& r
 
         if (target_ibeam != -1) {
 	    this->_slow_pulsar_writer_hash->get(target_ibeam, *source)
-+       ->set_params(target_beam, nfreq, ntime, nbins, base_path, source);
+        ->set_params(target_beam, nfreq, ntime, nbins, base_path, source);
 			     
 	    chlog("Pulsar writer parameter update" << std::endl << "\tnfreq_out: " << nfreq
                 << std::endl <<  "\tntime_out: " << ntime << std::endl << "\tnbins: " 

--- a/rfi_configs/rfi_16k_prod_test.json
+++ b/rfi_configs/rfi_16k_prod_test.json
@@ -1131,8 +1131,14 @@
         },
         {
             "class_name": "chime_slow_pulsar_writer",
-            "nt_chunk": 1024
-        }, 
+            "nt_chunk": 1024,
+            "name": "champss"
+        },
+        {
+            "class_name": "chime_slow_pulsar_writer",
+            "nt_chunk": 1024,
+            "name": "slow"
+        },
         {
             "class_name": "polynomial_detrender", 
             "epsilon": 0.01, 

--- a/rfi_configs/rfi_placeholder.json
+++ b/rfi_configs/rfi_placeholder.json
@@ -10,7 +10,13 @@
             },
             {
                 "class_name": "chime_slow_pulsar_writer",
-                "nt_chunk": 1024
+                "nt_chunk": 1024,
+                "name": "champss"
+            },
+            {
+                "class_name": "chime_slow_pulsar_writer",
+                "nt_chunk": 1024,
+                "name": "slow"
             }
         ], 
         "name": "pipeline"

--- a/slow_pulsar_writer_hash.hpp
+++ b/slow_pulsar_writer_hash.hpp
@@ -3,6 +3,7 @@
 
 #include <mutex>
 #include <rf_pipelines.hpp>
+#include <mask_stats.hpp>
 
 namespace ch_frb_l1 {
 #if 0
@@ -16,20 +17,20 @@ class slow_pulsar_writer_hash {
 public:
     using sp_writer = std::shared_ptr<rf_pipelines::chime_slow_pulsar_writer>;
 
-    void set(int beam_id, const sp_writer &sp)
+    void set(int beam_id, const std::string &source, const sp_writer &sp)
     {
 	std::lock_guard<std::mutex> ulock(_mutex);
-	_hash[beam_id] = sp;
+	_hash[{beam_id, source}] = sp;
     }
 
-    sp_writer get(int beam_id)
+    sp_writer get(int beam_id, const std::string &source)
     {
 	std::lock_guard<std::mutex> ulock(_mutex);
-	return _hash[beam_id];
+	return _hash[{beam_id, source}];
     }
     
 protected:
-    std::unordered_map<int, sp_writer> _hash;  
+    std::unordered_map<std::pair<int, std::string>, sp_writer, pair_hash> _hash; 
     std::mutex _mutex;
 };
 


### PR DESCRIPTION
(for CHAMPSS and Slow team) as well as handling of new "source" key in its pstate (e.g. making it a RPC call parameter, and as a key in the slow_pulsar_writer_hash table)

This is neccessary because CHAMPSS and Slow now want to record data for the same beam at the same time, but with different parameters.

Relevant PRs:
https://github.com/kmsmith137/rf_pipelines/pull/31
https://github.com/mrafieir/ch_frb_rfi/pull/10

Currently being tested and run on `cfdn1` under "sps-slow-test".

@dstndstn 